### PR TITLE
docker/Dockerfile: MAVEN_VERSION 3.8.7->3.9.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES \
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV WORKSPACE /workspace
-ENV MAVEN_VERSION 3.8.7
+ENV MAVEN_VERSION 3.9.2
 
 # Install dependencies
 RUN apt-get -qq update


### PR DESCRIPTION
Fixing the ever reoccurring 404 with the apache maven binary pull.